### PR TITLE
revert: changes to `isObject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Function documentation available [here](https://alcalzone.github.io/shared-utils
 	Placeholder for the next version (at the beginning of the line):
 	### __WORK IN PROGRESS__
 -->
+### __WORK IN PROGRESS__
+Undo changes to `isObject` from `4.0.6`. TS narrowing in 4.8.2 is broken.
+
 ### 4.0.6 (2022-09-07)
 * Fix: correctly narrow return type of `isObject`
 

--- a/src/sorted-list/sorted-list.test.ts
+++ b/src/sorted-list/sorted-list.test.ts
@@ -251,7 +251,7 @@ describe("sorted-list => ", () => {
 		expect(list[list.length]).to.be.undefined;
 	});
 
-	it.only("adding and removing should not break the doubly linked list", () => {
+	it("adding and removing should not break the doubly linked list", () => {
 		const list = new SortedList<number>();
 		list.add(2);
 		list.add(1);

--- a/src/typeguards/index.ts
+++ b/src/typeguards/index.ts
@@ -1,14 +1,8 @@
-type ExtractObject<T> =
-	T extends readonly unknown[] ? never
-	: {} extends T ? Record<string | number | symbol, unknown>
-	: T extends Record<string | number | symbol, unknown> ? T
-	: never;
-
 /**
  * Tests whether the given variable is a real object and not an Array
  * @param it The variable to test
  */
-export function isObject<T>(it: T): it is T & ExtractObject<T> {
+export function isObject<T>(it: T): it is T & Record<string, unknown> {
 	// This is necessary because:
 	// typeof null === 'object'
 	// typeof [] === 'object'

--- a/src/typeguards/typeguards.test.ts
+++ b/src/typeguards/typeguards.test.ts
@@ -7,7 +7,9 @@ import type { Equals } from "../types";
 function assertTrue<T extends true>() {
 	return undefined!;
 }
-type UnspecifiedObject = Record<string | number | symbol, unknown>;
+function assertFalse<T extends false>() {
+	return undefined!;
+}
 
 describe("lib/typeguards =>", () => {
 	describe("isObject() => ", () => {
@@ -34,79 +36,6 @@ describe("lib/typeguards =>", () => {
 		it("should allow sub-indexing objects", () => {
 			const foo = { a: { b: "c" } } as unknown;
 			isObject(foo) && isObject(foo.a) && isObject(foo.a.b);
-		});
-
-		it("inferred types are correct", () => {
-			const _any = undefined as any;
-			const _unknown = undefined as unknown;
-			const _unknownArray = _unknown as unknown[];
-			const _number = _unknown as number;
-			const _numberArray = _unknown as number[];
-			const _readonlyNumberArray = _unknown as readonly number[];
-			const _nonNullish = _unknown as {};
-			const _specificObjectNullable = _unknown as
-				| { a: number }
-				| undefined;
-			const _objectOrArray = _unknown as { a: number } | string[];
-
-			if (isObject(_any)) {
-				assertTrue<Equals<typeof _any, any>>();
-				_any;
-				// ^?
-			}
-
-			if (isObject(_unknown)) {
-				assertTrue<Equals<typeof _unknown, UnspecifiedObject>>();
-				_unknown;
-				// ^?
-			}
-
-			if (isObject(_unknownArray)) {
-				assertTrue<Equals<typeof _unknownArray, never>>();
-				_unknownArray;
-				// ^?
-			}
-
-			if (isObject(_number)) {
-				assertTrue<Equals<typeof _number, never>>();
-				_number;
-				// ^?
-			}
-
-			if (isObject(_numberArray)) {
-				assertTrue<Equals<typeof _numberArray, never>>();
-				_numberArray;
-				// ^?
-			}
-
-			if (isObject(_readonlyNumberArray)) {
-				assertTrue<Equals<typeof _readonlyNumberArray, never>>();
-				_readonlyNumberArray;
-				// ^?
-			}
-
-			if (isObject(_nonNullish)) {
-				assertTrue<Equals<typeof _nonNullish, UnspecifiedObject>>();
-				_nonNullish;
-				// ^?
-			}
-
-			if (isObject(_specificObjectNullable)) {
-				assertTrue<
-					Equals<
-						typeof _specificObjectNullable,
-						NonNullable<typeof _specificObjectNullable>
-					>
-				>();
-				_specificObjectNullable;
-				// ^?
-			}
-
-			if (isObject(_objectOrArray)) {
-				assertTrue<Equals<typeof _objectOrArray, { a: number }>>();
-				_objectOrArray;
-				// ^?
-			}
 		});
 	});
 


### PR DESCRIPTION
TS 4.8 narrowing is just broken for these cases